### PR TITLE
bug fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class WebpackDynamicPublicPath {
 
         const fileNames = chunks.map(
             chunk => chunk.files.find(
-                file => file.match(/.*\.js$/)
+                file => file.match(/.*\.js/)
             )
         );
 


### PR DESCRIPTION
nice job at first

I found a bug,if `output.filename=[name].js?[hash]`,the regexp can't match it,so we can't match `.js` at last.

please merge and release it, thx :blush: